### PR TITLE
fix_get_empty_playlistClips_error

### DIFF
--- a/src/routes/clips.ts
+++ b/src/routes/clips.ts
@@ -100,6 +100,12 @@ router.get('/', async (req: Request, res: Response) => {
             // クエリを実行して、clipId一覧取得
             const clipIds: object[] = [];
             const qs_playlist = await getDocs(q_playlist);
+
+            // プレイリストにクリップが登録されていなければ空の配列を返す
+            if (qs_playlist.empty) {
+                return res.status(200).json([]);
+            }
+
             qs_playlist.forEach((doc) => {
                 clipIds.push(doc.data()["clip_id"]);
             });


### PR DESCRIPTION
## 🔨 変更内容

- bug fix
- プレイリストにクリップが登録されていない場合にからの配列を返すようにした

## 📸 スクリーンショット

## 📢 この PR に含まないこと



## 💡 レビューの観点

### PR 作成者のチェック項目

- [ ] セルフレビュー
- [ ] Reviewer の指定

### Reviewer のチェック項目

<!-- PR 作成者が確認してほしいことを追記する-->
<!-- 例) ○○なときxxが△△になる -->

- [ ] コードレビュー

## ✅ 解決するイシュー

- close #20 

## 🤝 関連するイシュー

- #0
